### PR TITLE
Remove -fno-exceptions default

### DIFF
--- a/ndk_cc_toolchain_config.bzl
+++ b/ndk_cc_toolchain_config.bzl
@@ -653,7 +653,6 @@ def ndk_cc_toolchain_config(
                 flag_set(
                     actions = actions.all_cpp_compile,
                     flags = [
-                        "-fno-exceptions",
                         "-std=gnu++17",
                         "-Wc++2a-extensions",
                         "-Woverloaded-virtual",


### PR DESCRIPTION
This is part of https://github.com/bazelbuild/rules_android_ndk/issues/5

Users who want this should set `build --cxxopt=-fno-exceptions` in their `.bazelrc`