### PR TITLE
Disable warnings_as_errors by default

### DIFF
--- a/ndk_cc_toolchain_config.bzl
+++ b/ndk_cc_toolchain_config.bzl
@@ -533,10 +533,7 @@ def ndk_cc_toolchain_config(
         ),
 
         # User-settable feature controls warning aggressiveness for compilation.
-        feature(
-            name = "warnings_as_errors",
-            enabled = True,
-        ),
+        feature(name = "warnings_as_errors"),
 
         # Configure the header parsing and preprocessing. Blaze will test to see if
         # the Crosstool supports it if the cc_toolchain specifies


### PR DESCRIPTION
For folks who want this always they should set `build --features=warnings_as_errors` in their `.bazelrc`

This is part of https://github.com/bazelbuild/rules_android_ndk/issues/5