### PR TITLE
Disable cc_toolchain_resolution

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,6 +6,7 @@ platforms:
     environment:
       ANDROID_NDK_HOME: /opt/android-ndk-r25b
     build_flags:
+      - "--noincompatible_enable_cc_toolchain_resolution"
       - "--fat_apk_cpu=arm64-v8a,x86"
       - "--android_crosstool_top=@androidndk//:toolchain"
     build_targets:
@@ -15,6 +16,7 @@ platforms:
     environment:
       ANDROID_NDK_HOME: /Users/buildkite/android-ndk-r25b
     build_flags:
+      - "--noincompatible_enable_cc_toolchain_resolution"
       - "--fat_apk_cpu=arm64-v8a,x86"
       - "--android_crosstool_top=@androidndk//:toolchain"
     build_targets:


### PR DESCRIPTION
This should unblock LTS cut of Bazel.

Related to: https://github.com/bazelbuild/rules_android_ndk/issues/21
