### PR TITLE
Use path attr before ANDROID_NDK_HOME

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -23,9 +23,7 @@ def _android_ndk_repository_impl(ctx):
     Returns:
         A final dict of configuration attributes and values.
     """
-    ndk_path = ctx.attr.path
-    if ndk_path == None:
-        ndk_path = ctx.os.environ.get("ANDROID_NDK_HOME", None)
+    ndk_path = ctx.attr.path or ctx.os.environ.get("ANDROID_NDK_HOME", None)
     if not ndk_path:
         fail("Either the ANDROID_NDK_HOME environment variable or the " +
              "path attribute of android_ndk_repository must be set.")

--- a/rules.bzl
+++ b/rules.bzl
@@ -23,10 +23,9 @@ def _android_ndk_repository_impl(ctx):
     Returns:
         A final dict of configuration attributes and values.
     """
-
-    ndk_path = ctx.os.environ.get("ANDROID_NDK_HOME", None)
+    ndk_path = ctx.attr.path
     if ndk_path == None:
-        ndk_path = ctx.attr.path
+        ndk_path = ctx.os.environ.get("ANDROID_NDK_HOME", None)
     if not ndk_path:
         fail("Either the ANDROID_NDK_HOME environment variable or the " +
              "path attribute of android_ndk_repository must be set.")


### PR DESCRIPTION
Reading and accepting `ANDROID_NDK_HOME` over the provided path results in some misleading errors where the `rules_android_ndk` repo will completely ignore any `path` value that you pass during setup.