### PR TITLE
Switch default standard to C++20 (+gnu extensions)

### DIFF
--- a/ndk_cc_toolchain_config.bzl
+++ b/ndk_cc_toolchain_config.bzl
@@ -650,8 +650,7 @@ def ndk_cc_toolchain_config(
                 flag_set(
                     actions = actions.all_cpp_compile,
                     flags = [
-                        "-std=gnu++17",
-                        "-Wc++2a-extensions",
+                        "-std=gnu++20",
                         "-Woverloaded-virtual",
                         "-Wnon-virtual-dtor",
                         "-Wno-deprecated",


### PR DESCRIPTION
As in #5, I'd like to propose that we enable C++20 by default, since I know the NDK compilers support it.

No pressure. It just seems like a good opportunity before the interface hardens.


Also, while we're all here: Is this code shared with blaze still (hopefully, so improvements are shared both ways)? If so maybe there's an equivalent of has_cxx17_headers that should be enabled? (From a quick search, that seemed to be a blaze-specific feature.)