### PR TITLE
Update `android_ndk_repository` to also register the CC toolchains.

### DIFF
--- a/BUILD.ndk_clang.tpl
+++ b/BUILD.ndk_clang.tpl
@@ -1,21 +1,9 @@
 """Declarations for the NDK's Clang directory."""
+
 load("@{repository_name}//:ndk_cc_toolchain_config.bzl", "ndk_cc_toolchain_config_rule")
+load("//:target_systems.bzl", "TARGET_SYSTEM_NAMES")
 
 package(default_visibility = ["//visibility:public"])
-
-TARGET_SYSTEM_NAMES = (
-    "arm-linux-androideabi",
-    "aarch64-linux-android",
-    "i686-linux-android",
-    "x86_64-linux-android",
-)
-
-_CPU_CONSTRAINT = {
-    "arm-linux-androideabi": "@platforms//cpu:armv7",
-    "aarch64-linux-android": "@platforms//cpu:aarch64",
-    "i686-linux-android": "@platforms//cpu:x86_32",
-    "x86_64-linux-android": "@platforms//cpu:x86_64",
-}
 
 cc_toolchain_suite(
     name = "cc_toolchain_suite",
@@ -44,16 +32,6 @@ cc_toolchain_suite(
     supports_header_parsing = 0,
     toolchain_config = ":toolchain_config_%s" % target_system_name,
     toolchain_identifier = "toolchain_identifier_%s" % target_system_name,
-) for target_system_name in TARGET_SYSTEM_NAMES]
-
-[toolchain(
-    name = "toolchain_%s" % target_system_name,
-    toolchain = ":cc_toolchain_%s" % target_system_name,
-    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
-    target_compatible_with = [
-        "@platforms//os:android",
-        _CPU_CONSTRAINT[target_system_name],
-    ],
 ) for target_system_name in TARGET_SYSTEM_NAMES]
 
 [ndk_cc_toolchain_config_rule(

--- a/BUILD.ndk_root.tpl
+++ b/BUILD.ndk_root.tpl
@@ -2,7 +2,22 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("//:target_systems.bzl", "CPU_CONSTRAINT", "TARGET_SYSTEM_NAMES")
+
+exports_files(["target_systems.bzl"])
+
 alias(
     name = "toolchain",
     actual = "//{clang_directory}:cc_toolchain_suite",
 )
+
+# Loop over TARGET_SYSTEM_NAMES and define all toolchain targets.
+[toolchain(
+    name = "toolchain_%s" % target_system_name,
+    toolchain = "//{clang_directory}:cc_toolchain_%s" % target_system_name,
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+    target_compatible_with = [
+        "@platforms//os:android",
+        CPU_CONSTRAINT[target_system_name],
+    ],
+) for target_system_name in TARGET_SYSTEM_NAMES]

--- a/BUILD.ndk_sysroot.tpl
+++ b/BUILD.ndk_sysroot.tpl
@@ -2,12 +2,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-TARGET_SYSTEM_NAMES = (
-    "arm-linux-androideabi",
-    "aarch64-linux-android",
-    "i686-linux-android",
-    "x86_64-linux-android",
-)
+load("//:target_systems.bzl", "TARGET_SYSTEM_NAMES")
 
 filegroup(
     name = "all_files",

--- a/rules.bzl
+++ b/rules.bzl
@@ -118,4 +118,4 @@ def android_ndk_repository(name, **kwargs):
         name = name,
         **kwargs
     )
-    native.register_toolchains("@androidndk//:all")
+    native.register_toolchains("@%s//:all" % name)

--- a/rules.bzl
+++ b/rules.bzl
@@ -58,6 +58,14 @@ def _android_ndk_repository_impl(ctx):
     )
 
     ctx.template(
+        "target_systems.bzl",
+        Label("//:target_systems.bzl.tpl"),
+        {
+        },
+        executable = False,
+    )
+
+    ctx.template(
         "%s/BUILD" % clang_directory,
         Label("//:BUILD.ndk_clang.tpl"),
         {
@@ -71,7 +79,7 @@ def _android_ndk_repository_impl(ctx):
 
     ctx.template(
         "%s/BUILD" % sysroot_directory,
-        Label("//:BUILD.ndk_sysroot"),
+        Label("//:BUILD.ndk_sysroot.tpl"),
         {
             "{api_level}": str(api_level),
         },
@@ -96,7 +104,7 @@ def _create_symlinks(ctx, ndk_path, clang_directory, sysroot_directory):
         repo_relative_path = str(p).replace(ndk_path, "")
         ctx.symlink(p, repo_relative_path)
 
-android_ndk_repository = repository_rule(
+_android_ndk_repository = repository_rule(
     implementation = _android_ndk_repository_impl,
     attrs = {
         "path": attr.string(),
@@ -104,3 +112,10 @@ android_ndk_repository = repository_rule(
     },
     local = True,
 )
+
+def android_ndk_repository(name, **kwargs):
+    _android_ndk_repository(
+        name = name,
+        **kwargs
+    )
+    native.register_toolchains("@androidndk//:all")

--- a/target_systems.bzl.tpl
+++ b/target_systems.bzl.tpl
@@ -1,0 +1,16 @@
+"""Target systems supported by the NDK rules."""
+
+TARGET_SYSTEM_NAMES = (
+    "arm-linux-androideabi",
+    "aarch64-linux-android",
+    "i686-linux-android",
+    "x86_64-linux-android",
+)
+
+CPU_CONSTRAINT = {
+    "arm-linux-androideabi": "@platforms//cpu:armv7",
+    "aarch64-linux-android": "@platforms//cpu:aarch64",
+    "i686-linux-android": "@platforms//cpu:x86_32",
+    "x86_64-linux-android": "@platforms//cpu:x86_64",
+}
+


### PR DESCRIPTION
This is work towards enabling platforms and toolchains for Android builds (https://github.com/bazelbuild/bazel/issues/16285).