### PR TITLE
Enables backwards compatibility with include paths prefixed with "ndk/"

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -31,11 +31,11 @@ macos: &macos
 
 tasks:
   basic_example_ubuntu2004:
-    << : [ *ubuntu2004, *basic_example ]
+    <<: [*ubuntu2004, *basic_example]
   basic_example_macos:
-    << : [ *macos, *basic_example ]
+    <<: [*macos, *basic_example]
 
   cpu_features_ubuntu2004:
-    << : [ *ubuntu2004, *cpu_features ]
+    <<: [*ubuntu2004, *cpu_features]
   cpu_features_macos:
-    << : [ *macos, *cpu_features ]
+    <<: [*macos, *cpu_features]

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,28 +1,41 @@
 ---
 buildifier: latest
-matrix:
-  platform: ["ubuntu2004", "macos"]
+
+basic_example: &basic_example
+  working_directory: examples/basic
+  build_flags:
+    - "--noincompatible_enable_cc_toolchain_resolution"
+    - "--fat_apk_cpu=arm64-v8a,x86"
+    - "--android_crosstool_top=@androidndk//:toolchain"
+  build_targets:
+    - "//java/com/app:app"
+
+cpu_features: &cpu_features
+  working_directory: examples/cpu_features
+  build_flags:
+    - "--noincompatible_enable_cc_toolchain_resolution"
+    - "--cpu=arm64-v8a"
+    - "--crosstool_top=@androidndk//:toolchain"
+  build_targets:
+    - "//:all"
+
+ubuntu2004: &ubuntu2004
+  platform: ubuntu2004
+  environment:
+    - ANDROID_NDK_HOME=/opt/android-ndk-r25b
+
+macos: &macos
+  platform: macos
+  environment:
+    - ANDROID_NDK_HOME=/Users/buildkite/android-ndk-r25b
 
 tasks:
-  basic_example:
-    working_directory: examples/basic
-    platform: ${{ platform }}
-    shell_commands:
-      - '[ $(uname) == "Linux" ] && export ANDROID_NDK_HOME=/opt/android-ndk-r25b || export ANDROID_NDK_HOME=/Users/buildkite/android-ndk-r25b'
-    build_flags:
-      - "--noincompatible_enable_cc_toolchain_resolution"
-      - "--fat_apk_cpu=arm64-v8a,x86"
-      - "--android_crosstool_top=@androidndk//:toolchain"
-    build_targets:
-      - "//java/com/app:app"
-  cpu_features:
-    working_directory: examples/cpu_features
-    platform: ${{ platform }}
-    shell_commands:
-      - '[ $(uname) == "Linux" ] && export ANDROID_NDK_HOME=/opt/android-ndk-r25b || export ANDROID_NDK_HOME=/Users/buildkite/android-ndk-r25b'
-    build_flags:
-      - "--noincompatible_enable_cc_toolchain_resolution"
-      - "--cpu=arm64-v8a"
-      - "--crosstool_top=@androidndk//:toolchain"
-    build_targets:
-      - "//:all"
+  basic_example_ubuntu2004:
+    << : [ *ubuntu2004, *basic_example ]
+  basic_example_macos:
+    << : [ *macos, *basic_example ]
+
+  cpu_features_ubuntu2004:
+    << : [ *ubuntu2004, *cpu_features ]
+  cpu_features_macos:
+    << : [ *macos, *cpu_features ]

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -9,6 +9,8 @@ tasks:
     platform: ${{ platform }}
     shell_commands:
       - '[ $(uname) == "Linux" ] && export ANDROID_NDK_HOME=/opt/android-ndk-r25b || export ANDROID_NDK_HOME=/Users/buildkite/android-ndk-r25b'
+    environment:
+      - "ANDROID_NDK_HOME"
     build_flags:
       - "--noincompatible_enable_cc_toolchain_resolution"
       - "--fat_apk_cpu=arm64-v8a,x86"
@@ -20,6 +22,8 @@ tasks:
     platform: ${{ platform }}
     shell_commands:
       - '[ $(uname) == "Linux" ] && export ANDROID_NDK_HOME=/opt/android-ndk-r25b || export ANDROID_NDK_HOME=/Users/buildkite/android-ndk-r25b'
+    environment:
+      - "ANDROID_NDK_HOME"
     build_flags:
       - "--noincompatible_enable_cc_toolchain_resolution"
       - "--cpu=arm64-v8a"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,7 +4,7 @@ matrix:
   platform: ["ubuntu2004", "macos"]
 
 tasks:
-  basic_example_ubuntu2004:
+  basic_example:
     working_directory: examples/basic
     platform: ${{ platform }}
     shell_commands:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -8,7 +8,7 @@ tasks:
     working_directory: examples/basic
     platform: ${{ platform }}
     shell_commands:
-      - [ $(uname) == "Linux" ] && export ANDROID_NDK_HOME=/opt/android-ndk-r25b || export ANDROID_NDK_HOME=/Users/buildkite/android-ndk-r25b
+      - '[ $(uname) == "Linux" ] && export ANDROID_NDK_HOME=/opt/android-ndk-r25b || export ANDROID_NDK_HOME=/Users/buildkite/android-ndk-r25b'
     build_flags:
       - "--noincompatible_enable_cc_toolchain_resolution"
       - "--fat_apk_cpu=arm64-v8a,x86"
@@ -19,7 +19,7 @@ tasks:
     working_directory: examples/cpu_features
     platform: ${{ platform }}
     shell_commands:
-      - [ $(uname) == "Linux" ] && export ANDROID_NDK_HOME=/opt/android-ndk-r25b || export ANDROID_NDK_HOME=/Users/buildkite/android-ndk-r25b
+      - '[ $(uname) == "Linux" ] && export ANDROID_NDK_HOME=/opt/android-ndk-r25b || export ANDROID_NDK_HOME=/Users/buildkite/android-ndk-r25b'
     build_flags:
       - "--noincompatible_enable_cc_toolchain_resolution"
       - "--cpu=arm64-v8a"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -22,12 +22,12 @@ cpu_features: &cpu_features
 ubuntu2004: &ubuntu2004
   platform: ubuntu2004
   environment:
-    - ANDROID_NDK_HOME=/opt/android-ndk-r25b
+    ANDROID_NDK_HOME: /opt/android-ndk-r25b
 
 macos: &macos
   platform: macos
   environment:
-    - ANDROID_NDK_HOME=/Users/buildkite/android-ndk-r25b
+    ANDROID_NDK_HOME: /Users/buildkite/android-ndk-r25b
 
 tasks:
   basic_example_ubuntu2004:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -9,8 +9,6 @@ tasks:
     platform: ${{ platform }}
     shell_commands:
       - '[ $(uname) == "Linux" ] && export ANDROID_NDK_HOME=/opt/android-ndk-r25b || export ANDROID_NDK_HOME=/Users/buildkite/android-ndk-r25b'
-    environment:
-      - "ANDROID_NDK_HOME"
     build_flags:
       - "--noincompatible_enable_cc_toolchain_resolution"
       - "--fat_apk_cpu=arm64-v8a,x86"
@@ -22,8 +20,6 @@ tasks:
     platform: ${{ platform }}
     shell_commands:
       - '[ $(uname) == "Linux" ] && export ANDROID_NDK_HOME=/opt/android-ndk-r25b || export ANDROID_NDK_HOME=/Users/buildkite/android-ndk-r25b'
-    environment:
-      - "ANDROID_NDK_HOME"
     build_flags:
       - "--noincompatible_enable_cc_toolchain_resolution"
       - "--cpu=arm64-v8a"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,23 +1,28 @@
 ---
 buildifier: latest
-platforms:
-  ubuntu1804:
+matrix:
+  platform: ["ubuntu2004", "macos"]
+
+tasks:
+  basic_example_ubuntu2004:
     working_directory: examples/basic
-    environment:
-      ANDROID_NDK_HOME: /opt/android-ndk-r25b
+    platform: ${{ platform }}
+    shell_commands:
+      - [ $(uname) == "Linux" ] && export ANDROID_NDK_HOME=/opt/android-ndk-r25b || export ANDROID_NDK_HOME=/Users/buildkite/android-ndk-r25b
     build_flags:
       - "--noincompatible_enable_cc_toolchain_resolution"
       - "--fat_apk_cpu=arm64-v8a,x86"
       - "--android_crosstool_top=@androidndk//:toolchain"
     build_targets:
-    - "//java/com/app:app"
-  macos:
-    working_directory: examples/basic
-    environment:
-      ANDROID_NDK_HOME: /Users/buildkite/android-ndk-r25b
+      - "//java/com/app:app"
+  cpu_features:
+    working_directory: examples/cpu_features
+    platform: ${{ platform }}
+    shell_commands:
+      - [ $(uname) == "Linux" ] && export ANDROID_NDK_HOME=/opt/android-ndk-r25b || export ANDROID_NDK_HOME=/Users/buildkite/android-ndk-r25b
     build_flags:
       - "--noincompatible_enable_cc_toolchain_resolution"
-      - "--fat_apk_cpu=arm64-v8a,x86"
-      - "--android_crosstool_top=@androidndk//:toolchain"
+      - "--cpu=arm64-v8a"
+      - "--crosstool_top=@androidndk//:toolchain"
     build_targets:
-    - "//java/com/app:app"
+      - "//:all"

--- a/BUILD.ndk_root.tpl
+++ b/BUILD.ndk_root.tpl
@@ -26,12 +26,12 @@ cc_library(
     name = "cpufeatures",
     srcs = glob([
         "sources/android/cpufeatures/*.c",
-        # Remove this hack, see https://github.com/bazelbuild/rules_android_ndk/issues/32
+        # TODO(#32): Remove this hack
         "ndk/sources/android/cpufeatures/*.c",
     ]),
     hdrs = glob([
         "sources/android/cpufeatures/*.h",
-        # Remove this hack, see https://github.com/bazelbuild/rules_android_ndk/issues/32
+        # TODO(#32): Remove this hack
         "ndk/sources/android/cpufeatures/*.h",
     ]),
     linkopts = ["-ldl"],

--- a/BUILD.ndk_root.tpl
+++ b/BUILD.ndk_root.tpl
@@ -24,7 +24,15 @@ alias(
 
 cc_library(
     name = "cpufeatures",
-    srcs = glob(["sources/android/cpufeatures/*.c"]),
-    hdrs = glob(["sources/android/cpufeatures/*.h"]),
+    srcs = glob([
+        "sources/android/cpufeatures/*.c",
+        # Remove this hack, see https://github.com/bazelbuild/rules_android_ndk/issues/32
+        "ndk/sources/android/cpufeatures/*.c",
+    ]),
+    hdrs = glob([
+        "sources/android/cpufeatures/*.h",
+        # Remove this hack, see https://github.com/bazelbuild/rules_android_ndk/issues/32
+        "ndk/sources/android/cpufeatures/*.h",
+    ]),
     linkopts = ["-ldl"],
 )

--- a/examples/cpu_features/BUILD
+++ b/examples/cpu_features/BUILD
@@ -1,0 +1,14 @@
+cc_library(
+  name = "jni",
+  srcs = ["jni.cc"],
+  deps = ["@androidndk//:cpufeatures"],
+)
+
+# Used for testing cpu features included through "ndk/"-prefixed path.
+# Use #include "sources/android/cpufeatures/cpu-features.h" in future
+# code. See https://github.com/bazelbuild/rules_android_ndk/issues/32
+cc_library(
+  name = "jni_cpu_features_compat",
+  srcs = ["jni_cpu_features_compat.cc"],
+  deps = ["@androidndk//:cpufeatures"],
+)

--- a/examples/cpu_features/BUILD
+++ b/examples/cpu_features/BUILD
@@ -1,14 +1,14 @@
 cc_library(
-  name = "jni",
-  srcs = ["jni.cc"],
-  deps = ["@androidndk//:cpufeatures"],
+    name = "jni",
+    srcs = ["jni.cc"],
+    deps = ["@androidndk//:cpufeatures"],
 )
 
 # Used for testing cpu features included through "ndk/"-prefixed path.
 # Use #include "sources/android/cpufeatures/cpu-features.h" in future
 # code. See https://github.com/bazelbuild/rules_android_ndk/issues/32
 cc_library(
-  name = "jni_cpu_features_compat",
-  srcs = ["jni_cpu_features_compat.cc"],
-  deps = ["@androidndk//:cpufeatures"],
+    name = "jni_cpu_features_compat",
+    srcs = ["jni_cpu_features_compat.cc"],
+    deps = ["@androidndk//:cpufeatures"],
 )

--- a/examples/cpu_features/README.md
+++ b/examples/cpu_features/README.md
@@ -1,0 +1,5 @@
+To build, run:
+
+    bazel build :all --cpu=arm64-v8a --crosstool_top=@androidndk//:toolchain
+
+in this directory.

--- a/examples/cpu_features/README.md
+++ b/examples/cpu_features/README.md
@@ -3,3 +3,6 @@ To build, run:
     bazel build :all --cpu=arm64-v8a --crosstool_top=@androidndk//:toolchain
 
 in this directory.
+
+Prefer using https://github.com/google/cpu_features instead of the cpu_features
+target defined by android_ndk_repository.

--- a/examples/cpu_features/WORKSPACE
+++ b/examples/cpu_features/WORKSPACE
@@ -1,0 +1,12 @@
+android_sdk_repository(
+    name = "androidsdk",
+)
+
+local_repository(
+    name = "rules_android_ndk",
+    path = "../..",
+)
+
+load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
+
+android_ndk_repository(name = "androidndk")

--- a/examples/cpu_features/jni.cc
+++ b/examples/cpu_features/jni.cc
@@ -1,0 +1,22 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <jni.h>
+
+#include "sources/android/cpufeatures/cpu-features.h"
+
+extern "C" JNIEXPORT int JNICALL
+Java_com_app_Jni_getValue(JNIEnv *env, jclass clazz) {
+  return android_getCpuCount();
+}

--- a/examples/cpu_features/jni.cc
+++ b/examples/cpu_features/jni.cc
@@ -14,6 +14,9 @@
 
 #include <jni.h>
 
+// Prefer using https://github.com/google/cpu_features instead of the
+// cpu_features target defined by android_ndk_repository.
+// See https://github.com/bazelbuild/rules_android_ndk/issues/32
 #include "sources/android/cpufeatures/cpu-features.h"
 
 extern "C" JNIEXPORT int JNICALL

--- a/examples/cpu_features/jni_cpu_features_compat.cc
+++ b/examples/cpu_features/jni_cpu_features_compat.cc
@@ -1,0 +1,29 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <jni.h>
+
+// This is only for testing compatibilty with the previous
+// of implementation of android_ndk_repository. Use:
+//
+//    #include "sources/android/cpufeatures/cpu-features.h"
+//
+// in future code.
+// See https://github.com/bazelbuild/rules_android_ndk/issues/32
+#include "ndk/sources/android/cpufeatures/cpu-features.h"
+
+extern "C" JNIEXPORT int JNICALL
+Java_com_app_Jni_getValue(JNIEnv *env, jclass clazz) {
+  return android_getCpuCount();
+}

--- a/examples/cpu_features/jni_cpu_features_compat.cc
+++ b/examples/cpu_features/jni_cpu_features_compat.cc
@@ -15,11 +15,13 @@
 #include <jni.h>
 
 // This is only for testing compatibilty with the previous
-// of implementation of android_ndk_repository. Use:
+// of implementation of android_ndk_repository.
+// Prefer using https://github.com/google/cpu_features instead of the
+// cpu_features target defined by android_ndk_repository. If the cpu_features
+// target from android_ndk_repository must be used, use:
 //
 //    #include "sources/android/cpufeatures/cpu-features.h"
 //
-// in future code.
 // See https://github.com/bazelbuild/rules_android_ndk/issues/32
 #include "ndk/sources/android/cpufeatures/cpu-features.h"
 

--- a/rules.bzl
+++ b/rules.bzl
@@ -106,7 +106,7 @@ def _create_symlinks(ctx, ndk_path, clang_directory, sysroot_directory):
 
     ctx.symlink(ndk_path + "sources", "sources")
 
-    # Remove this hack, see https://github.com/bazelbuild/rules_android_ndk/issues/32
+    # TODO(#32): Remove this hack
     ctx.symlink(ndk_path + "sources", "ndk/sources")
 
 _android_ndk_repository = repository_rule(

--- a/rules.bzl
+++ b/rules.bzl
@@ -105,6 +105,8 @@ def _create_symlinks(ctx, ndk_path, clang_directory, sysroot_directory):
         ctx.symlink(p, repo_relative_path)
 
     ctx.symlink(ndk_path + "sources", "sources")
+    # Remove this hack, see https://github.com/bazelbuild/rules_android_ndk/issues/32
+    ctx.symlink(ndk_path + "sources", "ndk/sources")
 
 _android_ndk_repository = repository_rule(
     implementation = _android_ndk_repository_impl,

--- a/rules.bzl
+++ b/rules.bzl
@@ -105,16 +105,17 @@ def _create_symlinks(ctx, ndk_path, clang_directory, sysroot_directory):
         ctx.symlink(p, repo_relative_path)
 
     ctx.symlink(ndk_path + "sources", "sources")
+
     # Remove this hack, see https://github.com/bazelbuild/rules_android_ndk/issues/32
     ctx.symlink(ndk_path + "sources", "ndk/sources")
 
 _android_ndk_repository = repository_rule(
-    implementation = _android_ndk_repository_impl,
     attrs = {
         "path": attr.string(),
         "api_level": attr.int(),
     },
     local = True,
+    implementation = _android_ndk_repository_impl,
 )
 
 def android_ndk_repository(name, **kwargs):


### PR DESCRIPTION
Also adds tests, and a note about using https://github.com/google/cpu_features instead of the cpu_features target defined by android_ndk_repository.