### PR TITLE
Remove bazel pic features

### DIFF
--- a/ndk_cc_toolchain_config.bzl
+++ b/ndk_cc_toolchain_config.bzl
@@ -270,16 +270,6 @@ def ndk_cc_toolchain_config(
         # Blaze requests this feature by default, but we don't care.
         feature(name = "random_seed"),
 
-        # Formerly "needsPic" attribute
-        feature(
-            name = "supports_pic",
-            enabled = True,
-        ),
-
-        # Blaze requests this feature by default.
-        # Blaze tests if this feature is supported before setting the "pic" build-variable.
-        feature(name = "pic"),
-
         # Blaze requests this feature if fission is requested
         # Blaze tests if it's supported to see if we support fission.
         feature(name = "per_object_debug_info"),
@@ -880,7 +870,7 @@ def ndk_cc_toolchain_config(
                 flag_set(
                     actions = actions.all_compile,
                     flag_groups = [
-                        flag_group(flags = ["-fPIC"], expand_if_available = "pic"),
+                        flag_group(flags = ["-fPIC"]),
                     ],
                 ),
                 flag_set(


### PR DESCRIPTION
Bazel has some custom features for allowing users to enable / disable pic. As far as I can tell Android requires pic executables for a while. The easiest way to force this always is to ignore bazel's custom pic support and just always pass the `-fPIC` compiler flag. This avoids issues where other rulesets cannot easily know if pic should be enabled, and accidentally compile things without pic, leading to linker failures. Specifically I hit https://github.com/bazelbuild/rules_foreign_cc/issues/421

This is pretty similar to what iOS does as well where it just forces the pic feature on always https://github.com/bazelbuild/bazel/blob/24dbe0de1831697758c5732bc4210e75c7187393/tools/osx/crosstool/cc_toolchain_config.bzl#L1099-L1117