### PR TITLE
Build with incompatible_disallow_empty_glob

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,6 +4,7 @@ buildifier: latest
 basic_example: &basic_example
   working_directory: examples/basic
   build_flags:
+    - "--incompatible_disallow_empty_glob"
     - "--noincompatible_enable_cc_toolchain_resolution"
     - "--fat_apk_cpu=arm64-v8a,x86"
     - "--android_crosstool_top=@androidndk//:toolchain"
@@ -13,6 +14,7 @@ basic_example: &basic_example
 cpu_features: &cpu_features
   working_directory: examples/cpu_features
   build_flags:
+    - "--incompatible_disallow_empty_glob"
     - "--noincompatible_enable_cc_toolchain_resolution"
     - "--cpu=arm64-v8a"
     - "--crosstool_top=@androidndk//:toolchain"

--- a/BUILD.ndk_clang.tpl
+++ b/BUILD.ndk_clang.tpl
@@ -81,7 +81,7 @@ filegroup(
         "include/**",
         "lib/gcc/%s/**" % target_system_name,
         "lib64/**/*",
-    ]),
+    ], allow_empty = True),
     output_licenses = ["unencumbered"],
 ) for target_system_name in TARGET_SYSTEM_NAMES]
 
@@ -117,7 +117,7 @@ filegroup(
     ] + glob([
         "lib/gcc/%s/**" % target_system_name,
         "lib64/**",
-    ]),
+    ], allow_empty = True),
 ) for target_system_name in TARGET_SYSTEM_NAMES]
 
 filegroup(

--- a/BUILD.ndk_sysroot.tpl
+++ b/BUILD.ndk_sysroot.tpl
@@ -24,7 +24,7 @@ filegroup(
     srcs = glob([
         # "usr/lib/%s/**/*.so" % target_system_name,
         # "usr/lib/%s/**/*.a" % target_system_name,
-    ]),
+    ], allow_empty = True),
 ) for target_system_name in TARGET_SYSTEM_NAMES]
 
 [filegroup(


### PR DESCRIPTION
In order to flip the flag, all downstream projects should be adapted. However, it is hard to fix them all if there are constant regressions. Adding it to the CI will ensure that once the project can build with incompatible_disallow_empty_glob it can keep building like that.
See: bazelbuild/bazel#15327