### PR TITLE
Update to support NDK 26

### DIFF
--- a/BUILD.ndk_clang.tpl
+++ b/BUILD.ndk_clang.tpl
@@ -47,6 +47,7 @@ filegroup(
     srcs = glob([
       "bin/*",
       "lib64/**/*",
+      "lib/**/*",
     ]),
 )
 
@@ -81,6 +82,7 @@ filegroup(
         "include/**",
         "lib/gcc/%s/**" % target_system_name,
         "lib64/**/*",
+        "lib/**/*",
     ], allow_empty = True),
     output_licenses = ["unencumbered"],
 ) for target_system_name in TARGET_SYSTEM_NAMES]
@@ -117,6 +119,7 @@ filegroup(
     ] + glob([
         "lib/gcc/%s/**" % target_system_name,
         "lib64/**",
+        "lib/**",
     ], allow_empty = True),
 ) for target_system_name in TARGET_SYSTEM_NAMES]
 

--- a/BUILD.ndk_sysroot.tpl
+++ b/BUILD.ndk_sysroot.tpl
@@ -33,12 +33,12 @@ filegroup(
         "usr/lib/%s/libc++_static.a" % target_system_name,
         "usr/lib/%s/libc++abi.a" % target_system_name,
     ] + {
-        "arm-linux-androideabi": [
+        "arm-linux-androideabi": glob([
             "usr/lib/arm-linux-androideabi/libandroid_support.a",
-        ],
-        "i686-linux-android": [
+        ], allow_empty = True),
+        "i686-linux-android": glob([
             "usr/lib/i686-linux-android/libandroid_support.a",
-        ],
+        ], allow_empty = True),
     }.get(
         target_system_name,
         [],

--- a/BUILD.ndk_sysroot.tpl
+++ b/BUILD.ndk_sysroot.tpl
@@ -33,6 +33,8 @@ filegroup(
         "usr/lib/%s/libc++_static.a" % target_system_name,
         "usr/lib/%s/libc++abi.a" % target_system_name,
     ] + {
+        # libandroid_support was removed in NDK 26, so use a glob
+        # for backward compatibility.
         "arm-linux-androideabi": glob([
             "usr/lib/arm-linux-androideabi/libandroid_support.a",
         ], allow_empty = True),


### PR DESCRIPTION
The current NDK 26 beta moves a significant number of files from previous versions. lib64 no longer exists and everything is nested inside of lib/ instead. Some libraries were also removed.