### PR TITLE
Add rules_android dependency and fix platform flags on CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -5,9 +5,9 @@ basic_example: &basic_example
   working_directory: examples/basic
   build_flags:
     - "--incompatible_disallow_empty_glob"
-    - "--noincompatible_enable_cc_toolchain_resolution"
     - "--fat_apk_cpu=arm64-v8a,x86"
     - "--android_crosstool_top=@androidndk//:toolchain"
+    - "--android_platforms=@build_bazel_rules_android//:arm64-v8a,@build_bazel_rules_android//:x86"
   build_targets:
     - "//java/com/app:app"
 
@@ -15,9 +15,9 @@ cpu_features: &cpu_features
   working_directory: examples/cpu_features
   build_flags:
     - "--incompatible_disallow_empty_glob"
-    - "--noincompatible_enable_cc_toolchain_resolution"
     - "--cpu=arm64-v8a"
     - "--crosstool_top=@androidndk//:toolchain"
+    - "--platforms=@build_bazel_rules_android//:arm64-v8a"
   build_targets:
     - "//:all"
 

--- a/examples/cpu_features/WORKSPACE
+++ b/examples/cpu_features/WORKSPACE
@@ -10,3 +10,31 @@ local_repository(
 load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
 
 android_ndk_repository(name = "androidndk")
+
+# Import rules_android
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+RULES_ANDROID_COMMIT = "a54904b056250a213117cee9287c996cd042f388"
+
+RULES_ANDROID_SHA = "bf08c364e6d0946d09b485aee388557bba3bdb5f15323f73c2723d07d3503ba6"
+
+http_archive(
+    name = "build_bazel_rules_android",
+    sha256 = RULES_ANDROID_SHA,
+    strip_prefix = "rules_android-%s" % RULES_ANDROID_COMMIT,
+    url = "https://github.com/bazelbuild/rules_android/archive/%s.zip" % RULES_ANDROID_COMMIT,
+)
+
+load("@build_bazel_rules_android//:prereqs.bzl", "rules_android_prereqs")
+
+rules_android_prereqs()
+
+load("@build_bazel_rules_android//:defs.bzl", "rules_android_workspace")
+
+rules_android_workspace()
+
+register_toolchains(
+    "@build_bazel_rules_android//toolchains/android:android_default_toolchain",
+    "@build_bazel_rules_android//toolchains/android_sdk:android_sdk_tools",
+)


### PR DESCRIPTION
This makes it possible to enable C++ toolchain resolution in Bazel.