### PR TITLE
Add name to repo WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "rules_android_ndk")


### PR DESCRIPTION
The `WORKSPACE` file is missing the default workspace name.