### PR TITLE
Add .bcr configs for publishing to the central registry

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,3 @@
+fixedReleaser:
+  login: Bencodes
+  email: ben@ben.cm

--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,3 +1,3 @@
 fixedReleaser:
-  login: Bencodes
-  email: ben@ben.cm
+  login: ahumesky
+  email: ahumesky@google.com

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://github.com/bazelbuild/rules_android_ndk",
+    "maintainers": [
+        {
+            "email": "ben@ben.cm",
+            "github": "Bencodes",
+            "name": "Ben Lee"
+        }
+    ],
+    "repository": [
+        "github:bazelbuild/rules_android_ndk"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -2,9 +2,19 @@
     "homepage": "https://github.com/bazelbuild/rules_android_ndk",
     "maintainers": [
         {
+            "email": "ahumesky@google.com",
+            "github": "ahumesky",
+            "name": "ahumesky"
+        },
+        {
             "email": "ben@ben.cm",
             "github": "Bencodes",
             "name": "Ben Lee"
+        },
+        {
+            "email": "tedx@google.com",
+            "github": "ted-xie",
+            "name": "tedx"
         }
     ],
     "repository": [

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,30 @@
+matrix:
+  platform: ["macos", "ubuntu2004"]
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    working_directory: examples/basic
+    environment:
+      ANDROID_NDK_HOME: /opt/android-ndk-r25b
+    build_flags:
+      - "--noincompatible_enable_cc_toolchain_resolution"
+      - "--fat_apk_cpu=arm64-v8a,x86"
+      - "--android_crosstool_top=@androidndk//:toolchain"
+      - "--enable_bzlmod=False"
+    build_targets:
+      - "//java/com/app:app"
+  verify_targets_bzlmod:
+    name: "Verify build targets with bzlmod"
+    platform: ${{ platform }}
+    working_directory: examples/basic
+    environment:
+      ANDROID_NDK_HOME: /opt/android-ndk-r25b
+    build_flags:
+      - "--noincompatible_enable_cc_toolchain_resolution"
+      - "--fat_apk_cpu=arm64-v8a,x86"
+      - "--android_crosstool_top=@androidndk//:toolchain"
+      - "--enable_bzlmod=True"
+    build_targets:
+      - "//java/com/app:app"

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,10 +1,12 @@
 matrix:
   platform: ["macos", "ubuntu2004"]
+  bazel: ["7.x", "rolling
 
 tasks:
   verify_targets:
     name: "Verify build targets"
     platform: ${{ platform }}
+    bazel: ${{ bazel }}
     working_directory: examples/basic
     environment:
       ANDROID_NDK_HOME: /opt/android-ndk-r25b
@@ -18,6 +20,7 @@ tasks:
   verify_targets_bzlmod:
     name: "Verify build targets with bzlmod"
     platform: ${{ platform }}
+    bazel: ${{ bazel }}
     working_directory: examples/basic
     environment:
       ANDROID_NDK_HOME: /opt/android-ndk-r25b

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "",
+    "strip_prefix": "rules_android_ndk-{TAG}",
+    "url": "https://github.com/bazelbuild/rules_android_ndk/archive/refs/tags/{TAG}.tar.gz"
+}


### PR DESCRIPTION
Adding BCR configs to start publishing rules_android_ndk to the Bazel Central Registry.