### PR TITLE
Download the NDK in Bazel

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,28 @@ To use the Android NDK rules, add the following to your `WORKSPACE` file:
         sha256 = RULES_ANDROID_NDK_SHA,
         strip_prefix = "rules_android_ndk-%s" % RULES_ANDROID_NDK_COMMIT,
     )
-    load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
-    android_ndk_repository(name = "androidndk")
 
-Then, set the `ANDROID_NDK_HOME` environment variable or the `path` attribute of
-`android_ndk_repository` to the path of the local Android NDK installation
-directory.
+    load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
+    android_ndk_repository(name = "androidndk", version = "r25c")
+
+You can also customize the `base_url` attribute if, for example, you mirror the NDK archives
+on a private server.
+
+Some sha256 checksums are included in this repository, but these might not be up to date,
+if you want to use a version of the NDK that's not included, you can also specify the `sha256sums`
+attribute which maps platforms to checksums, like so:
+
+```
+android_ndk_repository(
+    name = "androidndk",
+    version = "r25c"
+    sha256sums = {
+        "windows": "f70093964f6cbbe19268f9876a20f92d3a593db3ad2037baadd25fd8d71e84e2",
+        "darwin": "b01bae969a5d0bfa0da18469f650a1628dc388672f30e0ba231da5c74245bc92",
+        "linux": "769ee342ea75f80619d985c2da990c48b3d8eaf45f48783a2d48870d04b46108",
+    }
+)
+```
 
 The `api_level` attribute can also be used to set the Android API level to build
 against.

--- a/examples/basic/WORKSPACE
+++ b/examples/basic/WORKSPACE
@@ -9,4 +9,7 @@ local_repository(
 
 load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
 
-android_ndk_repository(name = "androidndk")
+android_ndk_repository(
+    name = "androidndk",
+    version = "r25c",
+)

--- a/rules.bzl
+++ b/rules.bzl
@@ -38,11 +38,11 @@ def _android_ndk_repository_impl(ctx):
 
     ndk_version = ctx.attr.version
     ndk_platform = _ndk_platform(ctx)
-    ndk_default_url = "https://dl.google.com/android/repository/android-ndk-{version}-{platform}.zip".format(
+    ndk_url = "{base_url}/android-ndk-{version}-{platform}.zip".format(
+        base_url = ctx.attr.base_url,
         version = ndk_version,
         platform = ndk_platform,
     )
-    ndk_url = ctx.attr.urls.get(ndk_platform, ndk_default_url)
 
     filename = ndk_url.split("/")[-1]
     sha256 = ndk_sha256(filename, ctx)
@@ -118,7 +118,7 @@ _android_ndk_repository = repository_rule(
         "path": attr.string(),
         "api_level": attr.int(),
         "version": attr.string(default = "r25c"),
-        "urls": attr.string_dict(),
+        "base_url": attr.string(default = "https://dl.google.com/android/repository"),
         "sha256s": attr.string_dict(),
     },
     local = True,

--- a/sha256sums.bzl
+++ b/sha256sums.bzl
@@ -1,0 +1,30 @@
+"""
+SHA256 checksums for downloaded NDK archives
+"""
+
+_NDK_PACKAGE_SHA256SUMS = {
+    # r26
+    "android-ndk-r26-windows.zip": "",
+    "android-ndk-r26-darwin.zip": "b2ab2fd17f71e2d2994c8c0ba2e48e99377806e05bf7477093344c26ab71dec0",
+    "android-ndk-r26-linux.zip": "1505c2297a5b7a04ed20b5d44da5665e91bac2b7c0fbcd3ae99b6ccc3a61289a",
+    # r25c
+    "android-ndk-r25c-windows.zip": "f70093964f6cbbe19268f9876a20f92d3a593db3ad2037baadd25fd8d71e84e2",
+    "android-ndk-r25c-darwin.zip": "b01bae969a5d0bfa0da18469f650a1628dc388672f30e0ba231da5c74245bc92",
+    "android-ndk-r25c-linux.zip": "769ee342ea75f80619d985c2da990c48b3d8eaf45f48783a2d48870d04b46108",
+}
+
+def ndk_sha256(filename, repository_ctx):
+    """Get the sha256 for a specific NDK release
+
+    Args:
+        filename: the name of the NDK release file (as seen on https://developer.android.com/ndk/downloads)
+        repository_ctx: the repository_rule ctx
+
+    Returns:
+        a sha256sum string to use with ctx.download_and_extract
+    """
+    internal_sha256 = _NDK_PACKAGE_SHA256SUMS.get(filename)
+    external_sha256 = repository_ctx.attr.urls.get(filename)
+    if internal_sha256 == None and external_sha256 == None:
+        fail("This NDK version is unsupported, and you haven't supplied a custom sha256sum for", filename)
+    return _NDK_PACKAGE_SHA256SUMS.get(filename)

--- a/sha256sums.bzl
+++ b/sha256sums.bzl
@@ -4,7 +4,7 @@ SHA256 checksums for downloaded NDK archives
 
 _NDK_PACKAGE_SHA256SUMS = {
     # r26
-    "android-ndk-r26-windows.zip": "",
+    "android-ndk-r26-windows.zip": "a748c6634b96991e15cb8902ffa4a498bba2ec6aa8028526de3c4c9dfcf00663",
     "android-ndk-r26-darwin.zip": "b2ab2fd17f71e2d2994c8c0ba2e48e99377806e05bf7477093344c26ab71dec0",
     "android-ndk-r26-linux.zip": "1505c2297a5b7a04ed20b5d44da5665e91bac2b7c0fbcd3ae99b6ccc3a61289a",
     # r25c


### PR DESCRIPTION
The rule now ignores `ANDROID_NDK_HOME` and defaults to downloading the `r25c` NDK for the current platform (failing if the platform is not supported).

One can specify three new attributes:
- `version` to select the NDK to download
- `base_url` if you don't want to use `https://dl.google.com/android/repository`
- `sha256sums` to add checksums for (yet) unsupported NDK releases

Closes #44