### PR TITLE
Add a binding for external/android/crosstool so that the default value

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -127,3 +127,7 @@ def android_ndk_repository(name, **kwargs):
         **kwargs
     )
     native.register_toolchains("@%s//:all" % name)
+    native.bind(
+        name = "android/crosstool",
+        actual = "@%s//:toolchain" % name,
+    )


### PR DESCRIPTION
of `--android_crosstool_top` works.