### PR TITLE
Fix the nouse_workers_with_dexbuilder error

### DIFF
--- a/examples/basic/.bazelrc
+++ b/examples/basic/.bazelrc
@@ -1,4 +1,3 @@
 # For bazel 5.3.0, not necessary for 6.0.0+
 build --define=android_incremental_dexing_tool=d8_dexbuilder
 build --define=android_dexmerger_tool=d8_dexmerger
-build --nouse_workers_with_dexbuilder


### PR DESCRIPTION
With the recent changes of the  flag was removed in this commit in the Bazel https://github.com/bazelbuild/bazel/commit/f2c11f7f2225e0a881585bf866ce5117f3c51735.

This fixes the https://github.com/bazelbuild/rules_android_ndk/issues/53  t