### PR TITLE
Let users declare repository without registering the toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use the Android NDK rules, add the following to your `WORKSPACE` file:
         sha256 = RULES_ANDROID_NDK_SHA,
         strip_prefix = "rules_android_ndk-%s" % RULES_ANDROID_NDK_COMMIT,
     )
-    load("@rules_android_ndk//:rules.bzl", "android_ndk_register_toolchains")
+    load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
 
     android_ndk_repository(name = "androidndk")
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ To use the Android NDK rules, add the following to your `WORKSPACE` file:
         strip_prefix = "rules_android_ndk-%s" % RULES_ANDROID_NDK_COMMIT,
     )
     load("@rules_android_ndk//:rules.bzl", "android_ndk_register_toolchains")
-    android_ndk_register_toolchains(name = "androidndk")
+
+    android_ndk_repository(name = "androidndk")
+
+    register_toolchains("@androidndk//:all")
 
 Then, set the `ANDROID_NDK_HOME` environment variable or the `path` attribute of
 `android_ndk_repository` to the path of the local Android NDK installation

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ To use the Android NDK rules, add the following to your `WORKSPACE` file:
         sha256 = RULES_ANDROID_NDK_SHA,
         strip_prefix = "rules_android_ndk-%s" % RULES_ANDROID_NDK_COMMIT,
     )
-    load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
-    android_ndk_repository(name = "androidndk")
+    load("@rules_android_ndk//:rules.bzl", "android_ndk_register_toolchains")
+    android_ndk_register_toolchains(name = "androidndk")
 
 Then, set the `ANDROID_NDK_HOME` environment variable or the `path` attribute of
 `android_ndk_repository` to the path of the local Android NDK installation

--- a/examples/basic/WORKSPACE
+++ b/examples/basic/WORKSPACE
@@ -7,6 +7,6 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
+load("@rules_android_ndk//:rules.bzl", "android_ndk_register_toolchains")
 
-android_ndk_repository(name = "androidndk")
+android_ndk_register_toolchains(name = "androidndk")

--- a/examples/basic/WORKSPACE
+++ b/examples/basic/WORKSPACE
@@ -7,6 +7,8 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_android_ndk//:rules.bzl", "android_ndk_register_toolchains")
+load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
 
-android_ndk_register_toolchains(name = "androidndk")
+android_ndk_repository(name = "androidndk")
+
+register_toolchains("@androidndk//:all")

--- a/examples/cpu_features/WORKSPACE
+++ b/examples/cpu_features/WORKSPACE
@@ -7,6 +7,6 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
+load("@rules_android_ndk//:rules.bzl", "android_ndk_register_toolchains")
 
-android_ndk_repository(name = "androidndk")
+android_ndk_register_toolchains(name = "androidndk")

--- a/examples/cpu_features/WORKSPACE
+++ b/examples/cpu_features/WORKSPACE
@@ -7,6 +7,8 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_android_ndk//:rules.bzl", "android_ndk_register_toolchains")
+load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
 
-android_ndk_register_toolchains(name = "androidndk")
+android_ndk_repository(name = "androidndk")
+
+register_toolchains("@androidndk//:all")

--- a/rules.bzl
+++ b/rules.bzl
@@ -25,8 +25,8 @@ def _android_ndk_repository_impl(ctx):
     """
     ndk_path = ctx.attr.path or ctx.os.environ.get("ANDROID_NDK_HOME", None)
     if not ndk_path:
-        ctx.file("BUILD.bazel", "# No path to Android NDK was provided", executable = False)
-        return
+        fail("Either the ANDROID_NDK_HOME environment variable or the " +
+             "path attribute of android_ndk_repository must be set.")
 
     if ctx.os.name == "linux":
         clang_directory = "toolchains/llvm/prebuilt/linux-x86_64"

--- a/rules.bzl
+++ b/rules.bzl
@@ -120,14 +120,3 @@ android_ndk_repository = repository_rule(
     local = True,
     implementation = _android_ndk_repository_impl,
 )
-
-def android_ndk_register_toolchains(name = "androidndk", **kwargs):
-    android_ndk_repository(
-        name = name,
-        **kwargs
-    )
-    native.register_toolchains("@%s//:all" % name)
-    native.bind(
-        name = "android/crosstool",
-        actual = "@%s//:toolchain" % name,
-    )

--- a/rules.bzl
+++ b/rules.bzl
@@ -25,8 +25,8 @@ def _android_ndk_repository_impl(ctx):
     """
     ndk_path = ctx.attr.path or ctx.os.environ.get("ANDROID_NDK_HOME", None)
     if not ndk_path:
-        fail("Either the ANDROID_NDK_HOME environment variable or the " +
-             "path attribute of android_ndk_repository must be set.")
+        ctx.file("BUILD.bazel", "# No path to Android NDK was provided", executable = False)
+        return
 
     if ctx.os.name == "linux":
         clang_directory = "toolchains/llvm/prebuilt/linux-x86_64"

--- a/rules.bzl
+++ b/rules.bzl
@@ -112,7 +112,7 @@ def _create_symlinks(ctx, ndk_path, clang_directory, sysroot_directory):
     # TODO(#32): Remove this hack
     ctx.symlink(ndk_path + "sources", "ndk/sources")
 
-_android_ndk_repository = repository_rule(
+android_ndk_repository = repository_rule(
     attrs = {
         "path": attr.string(),
         "api_level": attr.int(),
@@ -121,8 +121,8 @@ _android_ndk_repository = repository_rule(
     implementation = _android_ndk_repository_impl,
 )
 
-def android_ndk_repository(name, **kwargs):
-    _android_ndk_repository(
+def android_ndk_register_toolchains(name = "androidndk", **kwargs):
+    android_ndk_repository(
         name = name,
         **kwargs
     )


### PR DESCRIPTION
This enables using `--extra_toolchains` on specific platforms, which is helpful when building a monorepo that has platforms without the Android SDK/NDK available.

Without this, it's impossible to use these rules if you're planning in a system where the NDK is unavailable (or not installed).