### PR TITLE
Support relative workspace paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ To use the Android NDK rules, add the following to your `WORKSPACE` file:
 
 Then, set the `ANDROID_NDK_HOME` environment variable or the `path` attribute of
 `android_ndk_repository` to the path of the local Android NDK installation
-directory.
+directory. If the path starts with `$WORKSPACE_ROOT`, then this string is
+replaced with the root path of the Bazel workspace.
 
 The `api_level` attribute can also be used to set the Android API level to build
 against.

--- a/rules.bzl
+++ b/rules.bzl
@@ -27,6 +27,8 @@ def _android_ndk_repository_impl(ctx):
     if not ndk_path:
         fail("Either the ANDROID_NDK_HOME environment variable or the " +
              "path attribute of android_ndk_repository must be set.")
+    if ndk_path.startswith("$WORKSPACE_ROOT"):
+        ndk_path = str(ctx.workspace_root) + ndk_path.removeprefix("$WORKSPACE_ROOT")
 
     is_windows = False
     executable_extension = ""


### PR DESCRIPTION
This makes it possible to reference the NDK path if it exists within the workspace. Using `--repo_env ANDROID_NDK_HOME=` for different OS platforms makes it possible to change the path for different configurations.