### PR TITLE
Run buildifier on all starlark sources

### DIFF
--- a/examples/basic/MODULE.bazel
+++ b/examples/basic/MODULE.bazel
@@ -1,7 +1,6 @@
 module(name = "basic_example")
 
 bazel_dep(name = "platforms", version = "0.0.10")
-
 bazel_dep(name = "rules_android_ndk")
 local_path_override(
     module_name = "rules_android_ndk",
@@ -10,15 +9,17 @@ local_path_override(
 
 android_ndk_repository_extension = use_extension("@rules_android_ndk//:extension.bzl", "android_ndk_repository_extension")
 use_repo(android_ndk_repository_extension, "androidndk")
+
 register_toolchains("@androidndk//:all")
 
 bazel_dep(name = "rules_android", version = "0.0.0")
+
 # TODO: Replace this with a released version once an updated
 # version is available on BCR.
 git_override(
     module_name = "rules_android",
-    remote = "https://github.com/bazelbuild/rules_android",
     commit = "e02da4d00ad81d44f1c8fd1b2ee46f057afdd392",
+    remote = "https://github.com/bazelbuild/rules_android",
 )
 
 register_toolchains(
@@ -28,4 +29,5 @@ register_toolchains(
 
 android_sdk_repository_extension = use_extension("@rules_android//rules/android_sdk_repository:rule.bzl", "android_sdk_repository_extension")
 use_repo(android_sdk_repository_extension, "androidsdk")
+
 register_toolchains("@androidsdk//:sdk-toolchain", "@androidsdk//:all")

--- a/examples/basic/MODULE.bazel
+++ b/examples/basic/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "rules_android", version = "0.0.0")
 # version is available on BCR.
 git_override(
     module_name = "rules_android",
-    commit = "e02da4d00ad81d44f1c8fd1b2ee46f057afdd392",
+    commit = "dd7b90c91fdc4edeca90ba9ebffa3c469b426a35",
     remote = "https://github.com/bazelbuild/rules_android",
 )
 

--- a/examples/basic/WORKSPACE
+++ b/examples/basic/WORKSPACE
@@ -25,11 +25,15 @@ http_archive(
 )
 
 load("@rules_android//:prereqs.bzl", "rules_android_prereqs")
+
 rules_android_prereqs()
+
 load("@rules_android//:defs.bzl", "rules_android_workspace")
+
 rules_android_workspace()
 
 load("@rules_android//rules:rules.bzl", "android_sdk_repository")
+
 # Requires that the ANDROID_HOME environment variable is set to the Android SDK path.
 android_sdk_repository(
     name = "androidsdk",

--- a/examples/basic/WORKSPACE
+++ b/examples/basic/WORKSPACE
@@ -15,11 +15,11 @@ register_toolchains("@androidndk//:all")
 
 # rules_android and Android SDK
 
-RULES_ANDROID_COMMIT = "e02da4d00ad81d44f1c8fd1b2ee46f057afdd392"
+RULES_ANDROID_COMMIT = "dd7b90c91fdc4edeca90ba9ebffa3c469b426a35"
 
 http_archive(
     name = "rules_android",
-    sha256 = "6f332645225c1a73b8a98136908822a25543ba21319ed5dc5c04f256e24aa8bd",
+    sha256 = "d0b310dd23442b8ff024cba73ad7564024b473673d8d5de7d01bd91adb9aa2d0",
     strip_prefix = "rules_android-" + RULES_ANDROID_COMMIT,
     urls = ["https://github.com/bazelbuild/rules_android/archive/%s.zip" % RULES_ANDROID_COMMIT],
 )

--- a/extension.bzl
+++ b/extension.bzl
@@ -33,7 +33,7 @@ def _android_ndk_repository_extension_impl(module_ctx):
 
     android_ndk_repository(
         name = "androidndk",
-        **kwargs,
+        **kwargs
     )
 
 android_ndk_repository_extension = module_extension(


### PR DESCRIPTION
... to address rules_android_ndk bazelCI failure.

`buildifier -v -r .`