### PR TITLE
Normalize ndk_path for Windows

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -24,6 +24,7 @@ def _android_ndk_repository_impl(ctx):
         A final dict of configuration attributes and values.
     """
     ndk_path = ctx.attr.path or ctx.os.environ.get("ANDROID_NDK_HOME", None)
+    ndk_path = ndk_path.replace("\\", "/")
     if not ndk_path:
         fail("Either the ANDROID_NDK_HOME environment variable or the " +
              "path attribute of android_ndk_repository must be set.")


### PR DESCRIPTION
Otherwise we may get this error:
```
ERROR: An error occurred during the fetch of repository 'rules_android_ndk~~android_ndk_repository_extension~androidndk':
   Traceback (most recent call last):
        File "C:/tmp/tq5vzwuk/external/rules_android_ndk~/rules.bzl", line 49, column 21, in _android_ndk_repository_impl
                _create_symlinks(ctx, ndk_path, clang_directory, sysroot_directory)
        File "C:/tmp/tq5vzwuk/external/rules_android_ndk~/rules.bzl", line 116, column 24, in _create_symlinks
                ctx.symlink(p, repo_relative_path)
Error in symlink: Cannot write outside of the repository directory for path C:/android_ndk/r25b/toolchains/llvm/prebuilt/windows-x86_64/AndroidVersion.txt
```