### PR TITLE
fix empty glob() error

### DIFF
--- a/BUILD.ndk_clang.tpl
+++ b/BUILD.ndk_clang.tpl
@@ -38,18 +38,23 @@ cc_toolchain_suite(
     name = "toolchain_config_%s" % target_system_name,
     api_level = {api_level},
     clang_resource_directory = "{clang_resource_directory}",
+    executable_extension = "{executable_extension}",
     target_system_name = target_system_name,
     toolchain_identifier = "toolchain_identifier_%s" % target_system_name,
-    executable_extension = "{executable_extension}",
 ) for target_system_name in TARGET_SYSTEM_NAMES]
 
 filegroup(
     name = "all_binaries",
-    srcs = glob([
-      "bin/*",
-      "lib64/**/*",
-      "lib/**/*",
-    ]),
+    srcs = glob(
+        [
+            "bin/*",
+            "lib64/**/*",
+            "lib/**/*",
+        ],
+        # Need to allow_empty here because previous NDK versions had 
+        # "lib" & "lib64" directories but recent ones only have "lib".
+        allow_empty = True,
+    ),
 )
 
 filegroup(
@@ -69,7 +74,6 @@ filegroup(
     output_licenses = ["unencumbered"],
 )
 
-
 [filegroup(
     name = "compiler_files_%s" % target_system_name,
     srcs = [
@@ -78,23 +82,24 @@ filegroup(
         ":as_files",
         ":objcopy_files",
         "//{sysroot_directory}:sysroot_includes",
-    ] + glob([
-        "prebuilt_include/**",
-        "include/**",
-        "lib/gcc/%s/**" % target_system_name,
-        "lib64/**/*",
-        "lib/**/*",
-    ], allow_empty = True),
+    ] + glob(
+        [
+            "prebuilt_include/**",
+            "include/**",
+            "lib/gcc/%s/**" % target_system_name,
+            "lib64/**/*",
+            "lib/**/*",
+        ],
+        allow_empty = True,
+    ),
     output_licenses = ["unencumbered"],
 ) for target_system_name in TARGET_SYSTEM_NAMES]
-
 
 filegroup(
     name = "coverage_files",
     srcs = [":all_binaries"],
     output_licenses = ["unencumbered"],
 )
-
 
 filegroup(
     name = "dwp_files",
@@ -117,11 +122,14 @@ filegroup(
     srcs = [
         ":all_binaries",
         ":static_runtime_lib_%s" % target_system_name,
-    ] + glob([
-        "lib/gcc/%s/**" % target_system_name,
-        "lib64/**",
-        "lib/**",
-    ], allow_empty = True),
+    ] + glob(
+        [
+            "lib/gcc/%s/**" % target_system_name,
+            "lib64/**",
+            "lib/**",
+        ],
+        allow_empty = True,
+    ),
 ) for target_system_name in TARGET_SYSTEM_NAMES]
 
 filegroup(


### PR DESCRIPTION
tl;dr : the issue description and repro: https://github.com/gdevillele/debug_bazel

I am trying to build native C libs for Android using Bazel and `rules_android_ndk`, and am getting the following error:

```
glob pattern 'lib64/**/*' didn't match anything, but allow_empty is set to False
```

This is due to a breaking change introduced in Bazel 8.0.
(https://github.com/bazelbuild/bazel/issues/8195)

Note: I am still a beginner with Bazel, so let me know if this is not the correct way of fixing this.
Thank you 🙂 