### PR TITLE
Use `ctx.getenv` to get NDK home

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -23,7 +23,7 @@ def _android_ndk_repository_impl(ctx):
     Returns:
         A final dict of configuration attributes and values.
     """
-    ndk_path = ctx.attr.path or ctx.os.environ.get("ANDROID_NDK_HOME", None)
+    ndk_path = ctx.attr.path or ctx.getenv("ANDROID_NDK_HOME", None)
     if not ndk_path:
         fail("Either the ANDROID_NDK_HOME environment variable or the " +
              "path attribute of android_ndk_repository must be set.")


### PR DESCRIPTION
From [here](https://bazel.build/rules/lib/builtins/repository_os.html#environ), seems like `ctx.os.environ` doesn't establish a dependency from the repository rule to the environment variable. It seems like we want the dependency here.