### PR TITLE
Fix bug #107: Turn Windows path to Linux one

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -104,6 +104,7 @@ def _android_ndk_repository_impl(ctx):
 # Manually create a partial symlink tree of the NDK to avoid creating BUILD
 # files in the real NDK directory.
 def _create_symlinks(ctx, ndk_path, clang_directory, sysroot_directory):
+    ndk_path = str(ndk_path).replace("\\", "/")
     # Path needs to end in "/" for replace() below to work
     if not ndk_path.endswith("/"):
         ndk_path = ndk_path + "/"


### PR DESCRIPTION
The value of $ANDROID_NDK_HOME in my environment is
C:\Users\rob\AppData\Local\Android\Sdk\ndk\28.0.13004108

ndk_path is set to that value, while p in line 112 is set to the paths using forward slashes, leading to failure of string.replace to find the substring ndk_path.

Solution:
Reset ndk_path to use forward slashes.




