### PR TITLE
Update BUILD.ndk_sysroot.tpl

### DIFF
--- a/BUILD.ndk_sysroot.tpl
+++ b/BUILD.ndk_sysroot.tpl
@@ -16,7 +16,7 @@ filegroup(
         "usr/lib/{target_system_name}/{api_level}/*".format(
             target_system_name = target_system_name,
         ),
-    ]),
+    ], allow_empty = True),
 ) for target_system_name in TARGET_SYSTEM_NAMES]
 
 [filegroup(


### PR DESCRIPTION
With NDK 21, it looks like this glob() can return an empty list which breaks. With NDK 29 no issues. Adding allow_empty=True to fix it.