### PR TITLE
Pass api_level to API_LEVEL

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -75,6 +75,7 @@ def _android_ndk_repository_impl(ctx):
         "target_systems.bzl",
         ctx.attr._template_target_systems,
         {
+            "{api_level}": str(api_level),
         },
         executable = False,
     )

--- a/target_systems.bzl.tpl
+++ b/target_systems.bzl.tpl
@@ -14,3 +14,4 @@ CPU_CONSTRAINT = {
     "x86_64-linux-android": "@platforms//cpu:x86_64",
 }
 
+API_LEVEL = {api_level}


### PR DESCRIPTION
Ability to get api_level to be able to reuse it in other custom rules.