### PR TITLE
Updates android builds to always use 16KB memory pages

### DIFF
--- a/ndk_cc_toolchain_config.bzl
+++ b/ndk_cc_toolchain_config.bzl
@@ -768,11 +768,6 @@ def ndk_cc_toolchain_config(
                     flags = ["-Wl,--fix-cortex-a8", "-march=armv7-a"],
                     features = ["crosstool_cpu_arm"],
                 ),
-                flag_set(
-                    actions = actions.all_link,
-                    flags = ["-Wl,-z,max-page-size=4096"],
-                    features = ["crosstool_cpu_arm64", "crosstool_linker_lld"],
-                ),
 
                 # X86 options
                 flag_set(
@@ -933,6 +928,9 @@ def ndk_cc_toolchain_config(
                         # Force JNI symbols to be linked.
                         "-Wl,--undefined-glob='Java_*'",
                         "-Wl,--undefined-glob='JNI_*'",
+                        # 16KB page alignment for Android 15+ compatibility
+                        "-Wl,-z,max-page-size=16384",
+                        "-Wl,-z,common-page-size=16384",
                     ],
                 ),
                 flag_set(


### PR DESCRIPTION
### Description

Android expects apps to support 16KB memory page alignments, otherwise it'll complain. This PR updates the linking flags to default to 16KB memory pages. For more details see https://developer.android.com/guide/practices/page-sizes.

