### PR TITLE
Remove problematic quotes in the --undefined-glob linker argument

### DIFF
--- a/ndk_cc_toolchain_config.bzl
+++ b/ndk_cc_toolchain_config.bzl
@@ -934,8 +934,8 @@ def ndk_cc_toolchain_config(
                         "-Wl,--exclude-libs,libgcc.a",
                         "-Wl,--build-id=md5",
                         # Force JNI symbols to be linked.
-                        "-Wl,--undefined-glob='Java_*'",
-                        "-Wl,--undefined-glob='JNI_*'",
+                        "-Wl,--undefined-glob=Java_*",
+                        "-Wl,--undefined-glob=JNI_*",
                         # 16KB page alignment for Android 15+ compatibility
                         "-Wl,-z,max-page-size=16384",
                         "-Wl,-z,common-page-size=16384",


### PR DESCRIPTION
The argument with quotes work because bazel use a response file[1] to pass the parameters to the linker. When the linker parse the response file, unncessary quotes are removed. But if the parameters are short, and bazel directly calls the linker with the arguments, the extra quotes unexpectedly become part of the pattern that the --undefined-glob argument tries to match. As a result, the linker may strip symbols starting with JNI_ or Java_ unexpectedly.

In addition, it breaks the `meson` rule from `rules_foreign_cc`, because `meson` always passes the arguments to the linker as process arguments directly. And `meson`'s native files/cross files don't support single quote in `cpp_link_args` anyway[2].

[1]: https://gcc.gnu.org/wiki/Response_Files
[2]: https://github.com/mesonbuild/meson/issues/15573