### PR TITLE
Fix Bazel@HEAD: Remove incompatible_enable_android_toolchain_resolution

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -12,7 +12,6 @@ basic_example: &basic_example
   working_directory: examples/basic
   build_flags:
     - "--incompatible_disallow_empty_glob"
-    - "--incompatible_enable_android_toolchain_resolution"
     - "--android_platforms=//:arm64-v8a,//:x86"
     - "--enable_bzlmod=False"
     - "--enable_workspace=True"
@@ -23,7 +22,6 @@ basic_example_bzlmod: &basic_example_bzlmod
   working_directory: examples/basic
   build_flags:
     - "--incompatible_disallow_empty_glob"
-    - "--incompatible_enable_android_toolchain_resolution"
     - "--android_platforms=//:arm64-v8a,//:x86"
   build_targets:
     - "//java/com/app:app"
@@ -32,7 +30,6 @@ cpu_features: &cpu_features
   working_directory: examples/cpu_features
   build_flags:
     - "--incompatible_disallow_empty_glob"
-    - "--incompatible_enable_android_toolchain_resolution"
     - "--platforms=//:arm64-v8a"
     - "--enable_workspace=True"
   build_targets:
@@ -42,7 +39,6 @@ toolchain_features: &toolchain_features
   working_directory: examples/toolchain_features
   build_flags:
     - "--incompatible_disallow_empty_glob"
-    - "--incompatible_enable_android_toolchain_resolution"
     - "--android_platforms=//:arm64-v8a,//:x86"
     - "--enable_bzlmod=True"
   build_targets:


### PR DESCRIPTION
This is a fix for broken [Bazel@HEAD](https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/5531#019eaa94-5b4e-4810-98a7-1428daac65e3).


This flag is not needed anymore since it's set to `True` by default from Bazel 7.