### PR TITLE
Fix examples for Bazel@HEAD

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -12,7 +12,6 @@ basic_example: &basic_example
   working_directory: examples/basic
   build_flags:
     - "--incompatible_disallow_empty_glob"
-    - "--incompatible_enable_android_toolchain_resolution"
     - "--android_platforms=//:arm64-v8a,//:x86"
     - "--enable_bzlmod=False"
     - "--enable_workspace=True"
@@ -23,7 +22,6 @@ basic_example_bzlmod: &basic_example_bzlmod
   working_directory: examples/basic
   build_flags:
     - "--incompatible_disallow_empty_glob"
-    - "--incompatible_enable_android_toolchain_resolution"
     - "--android_platforms=//:arm64-v8a,//:x86"
   build_targets:
     - "//java/com/app:app"
@@ -32,7 +30,6 @@ cpu_features: &cpu_features
   working_directory: examples/cpu_features
   build_flags:
     - "--incompatible_disallow_empty_glob"
-    - "--incompatible_enable_android_toolchain_resolution"
     - "--platforms=//:arm64-v8a"
     - "--enable_workspace=True"
   build_targets:
@@ -42,7 +39,6 @@ toolchain_features: &toolchain_features
   working_directory: examples/toolchain_features
   build_flags:
     - "--incompatible_disallow_empty_glob"
-    - "--incompatible_enable_android_toolchain_resolution"
     - "--android_platforms=//:arm64-v8a,//:x86"
     - "--enable_bzlmod=True"
   build_targets:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,8 +4,7 @@ matrix:
   bazel: [
     7.4.1,
     8.6.0,
-# TODO: re-enable last_green once bazelbuild/rules_android#328 is resolved.
-#    last_green,
+    last_green,
   ]
 
 basic_example: &basic_example
@@ -13,8 +12,6 @@ basic_example: &basic_example
   build_flags:
     - "--incompatible_disallow_empty_glob"
     - "--android_platforms=//:arm64-v8a,//:x86"
-    - "--enable_bzlmod=False"
-    - "--enable_workspace=True"
   build_targets:
     - "//java/com/app:app"
 
@@ -44,17 +41,12 @@ toolchain_features: &toolchain_features
   build_targets:
     - "//java/com/app:app"
 
-ubuntu2004: &ubuntu2004
-  platform: ubuntu2004
+ubuntu2404: &ubuntu2404
+  platform: ubuntu2404
   environment:
     ANDROID_NDK_HOME: /opt/android-ndk-r25b
 
 macos: &macos
-  platform: macos
-  environment:
-    ANDROID_NDK_HOME: /Users/buildkite/android-ndk-r25b
-
-macos: &macos_arm64
   platform: macos_arm64
   environment:
     ANDROID_NDK_HOME: /Users/buildkite/android-ndk-r25b
@@ -66,14 +58,14 @@ windows: &windows
     BAZELCI_LOCAL_RUN: true
 
 tasks:
-  basic_example_ubuntu2004:
+  basic_example_ubuntu2404:
     name: Basic Example
     bazel: ${{ bazel }}
-    <<: [*ubuntu2004, *basic_example]
-  basic_example_bzlmod_ubuntu2004:
+    <<: [*ubuntu2404, *basic_example]
+  basic_example_bzlmod_ubuntu2404:
     name: Basic Example Bzlmod
     bazel: ${{ bazel }}
-    <<: [*ubuntu2004, *basic_example_bzlmod]
+    <<: [*ubuntu2404, *basic_example_bzlmod]
   basic_example_macos:
     name: Basic Example
     bazel: ${{ bazel }}
@@ -81,7 +73,7 @@ tasks:
   basic_example_bzlmod_macos:
     name: Basic Example Bzlmod
     bazel: ${{ bazel }}
-    <<: [*macos_arm64, *basic_example_bzlmod]
+    <<: [*macos, *basic_example_bzlmod]
   basic_example_windows:
     name: Basic Example
     bazel: ${{ bazel }}
@@ -92,23 +84,23 @@ tasks:
     <<: [*windows, *basic_example_bzlmod]
 
 
-  cpu_features_ubuntu2004:
+  cpu_features_ubuntu2404:
     name: CPU Features
     bazel: ${{ bazel }}
-    <<: [*ubuntu2004, *cpu_features]
+    <<: [*ubuntu2404, *cpu_features]
   cpu_features_macos:
     name: CPU Features
     bazel: ${{ bazel }}
     <<: [*macos, *cpu_features]
 
-  toolchain_features_ubuntu2004:
+  toolchain_features_ubuntu2404:
     name: Toolchain Features
     bazel: ${{ bazel }}
-    <<: [*ubuntu2004, *toolchain_features]
+    <<: [*ubuntu2404, *toolchain_features]
   toolchain_features_macos:
     name: Toolchain Features
     bazel: ${{ bazel }}
-    <<: [*macos_arm64, *toolchain_features]
+    <<: [*macos, *toolchain_features]
   toolchain_features_windows:
     name: Toolchain Features
     bazel: ${{ bazel }}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["macos", "ubuntu2004", "windows"]
+  platform: ["macos_arm64", "ubuntu2404", "windows"]
   bazel: ["7.2.1", "7.3.x", "rolling"]
 
 tasks:

--- a/examples/basic/.bazelrc
+++ b/examples/basic/.bazelrc
@@ -7,3 +7,9 @@ common --experimental_google_legacy_api
 common --experimental_enable_android_migration_apis
 
 common --android_sdk=@androidsdk//:sdk
+
+build --tool_java_language_version=17
+build --java_language_version=17
+build --java_runtime_version=17
+build --tool_java_runtime_version=17
+build --platforms=//:arm64-v8a

--- a/examples/basic/MODULE.bazel
+++ b/examples/basic/MODULE.bazel
@@ -2,6 +2,7 @@ module(name = "basic_example")
 
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "bazel_worker_java", version = "0.0.11")
 bazel_dep(name = "rules_android_ndk", version = "0.1.6")
 local_path_override(
     module_name = "rules_android_ndk",
@@ -13,7 +14,7 @@ use_repo(android_ndk_repository_extension, "androidndk")
 
 register_toolchains("@androidndk//:all")
 
-bazel_dep(name = "rules_android", version = "0.7.1")
+bazel_dep(name = "rules_android", version = "0.7.3")
 
 register_toolchains(
     "@rules_android//toolchains/android:android_default_toolchain",

--- a/examples/basic/WORKSPACE
+++ b/examples/basic/WORKSPACE
@@ -11,15 +11,23 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_android",
-    sha256 = "af84b69ab3d16dd1a41056286e6511f147a94ccea995603e13e934c915c1631c",
-    strip_prefix = "rules_android-0.6.0",
-    url = "https://github.com/bazelbuild/rules_android/releases/download/v0.6.0/rules_android-v0.6.0.tar.gz",
+    sha256 = "c4cd258d3761eff08ee044c0252179bb6ee8af8ab24f7dafb73b280eeda98243",
+    strip_prefix = "rules_android-0.7.3",
+    url = "https://github.com/bazelbuild/rules_android/releases/download/v0.7.3/rules_android-v0.7.3.tar.gz",
 )
 
 # Android rules dependencies
 load("@rules_android//:prereqs.bzl", "rules_android_prereqs")
 
 rules_android_prereqs()
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
+load("@rules_cc//cc:extensions.bzl", "compatibility_proxy_repo")
+
+compatibility_proxy_repo()
 
 ##### rules_java setup for rules_android #####
 load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")

--- a/examples/cpu_features/.bazelrc
+++ b/examples/cpu_features/.bazelrc
@@ -2,4 +2,5 @@
 common --experimental_google_legacy_api
 common --experimental_enable_android_migration_apis
 
+build --platforms=//:arm64-v8a
 common --android_sdk=@androidsdk//:sdk

--- a/examples/cpu_features/MODULE.bazel
+++ b/examples/cpu_features/MODULE.bazel
@@ -1,0 +1,14 @@
+module(name = "cpu_features")
+
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "rules_android_ndk", version = "0.1.6")
+local_path_override(
+    module_name = "rules_android_ndk",
+    path = "../..",
+)
+
+android_ndk_repository_extension = use_extension("@rules_android_ndk//:extension.bzl", "android_ndk_repository_extension")
+use_repo(android_ndk_repository_extension, "androidndk")
+
+register_toolchains("@androidndk//:all")

--- a/examples/cpu_features/WORKSPACE
+++ b/examples/cpu_features/WORKSPACE
@@ -13,15 +13,23 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_android",
-    sha256 = "af84b69ab3d16dd1a41056286e6511f147a94ccea995603e13e934c915c1631c",
-    strip_prefix = "rules_android-0.6.0",
-    url = "https://github.com/bazelbuild/rules_android/releases/download/v0.6.0/rules_android-v0.6.0.tar.gz",
+    sha256 = "c4cd258d3761eff08ee044c0252179bb6ee8af8ab24f7dafb73b280eeda98243",
+    strip_prefix = "rules_android-0.7.3",
+    url = "https://github.com/bazelbuild/rules_android/releases/download/v0.7.3/rules_android-v0.7.3.tar.gz",
 )
 
 # Android rules dependencies
 load("@rules_android//:prereqs.bzl", "rules_android_prereqs")
 
 rules_android_prereqs()
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
+load("@rules_cc//cc:extensions.bzl", "compatibility_proxy_repo")
+
+compatibility_proxy_repo()
 
 ##### rules_java setup for rules_android #####
 load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")

--- a/examples/toolchain_features/.bazelrc
+++ b/examples/toolchain_features/.bazelrc
@@ -1,5 +1,5 @@
 common --android_sdk=@androidsdk//:sdk
-
+build --platforms=//:arm64-v8a
 # Support passing archiver and compiler parameters through a param file
 # Useful for platforms with low arg count limit (e.g Windows)
 build --features=archive_param_file

--- a/examples/toolchain_features/MODULE.bazel
+++ b/examples/toolchain_features/MODULE.bazel
@@ -13,7 +13,7 @@ use_repo(android_ndk_repository_extension, "androidndk")
 
 register_toolchains("@androidndk//:all")
 
-bazel_dep(name = "rules_android", version = "0.7.2")
+bazel_dep(name = "rules_android", version = "0.7.3")
 
 register_toolchains(
     "@rules_android//toolchains/android:android_default_toolchain",


### PR DESCRIPTION
Fixes errors on [Downstream](https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/5533#_).

Key Fixes:
* Bumped `rules_android` to `0.7.3`: Resolves a bug where the Android SDK tools were missing visibility, causing analysis errors.
* Fixed NDK C++ Toolchain Resolution: Added `build --platforms=//:arm64-v8a`to the `.bazelrc` files. This ensures that top-level `cc_library` targets and `android_binary` dependencies correctly use the Android NDK compiler instead of defaulting to the host Linux compiler.
* Enforced `Java 17` Configuration: Added Java 17 toolchain flags to the `.bazelrc` files. This fixes `UnsupportedClassVersionError` crashes because `rules_android` 0.7.3 requires Java 14+ for its internal tooling.